### PR TITLE
deps: Upgrade various Python deps

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ from setuptools import setup
 requirements = {
     'src' : [
         'astunparse==1.6.3',
-        'numpy==1.22.3',
-        'scipy==1.8.0',
+        'numpy==1.23.1',
+        'scipy==1.8.1',
         'sympy==1.10.1',
     ],
     'magics' : [
@@ -24,9 +24,9 @@ requirements = {
         'pygraphviz==1.5',
     ],
     'tests' : [
-        'pytest-timeout==1.3.3',
-        'pytest==5.2.2',
-        'coverage==5.3',
+        'pytest-timeout==2.1.0',
+        'pytest==7.1.2',
+        'coverage==6.4.2',
     ]
 }
 requirements['all'] = [r for v in requirements.values() for r in v]


### PR DESCRIPTION
Hi from an OSS contributor working with @schaechtle2 on engineering and packaging at ProbComp. We use Nix with `nixpkgs` to distribute our software including things that depend on Nix. We are not broken but some workflows are made awkward due to how not all versions of each python package are available on Nixpkgs.

Rather than forking nixpkgs to support outdated packages like `numpy 1.22.x`, this PR just makes a minimal delta in SPPL to forwards-only upgrade these dependencies. A bigger step could later be  taken to upgrade everything to latest-compatible, but that is out of scope.

We also use Python 3.9 with SPPL, and so are hopeful in this PR's inclusion of 3.9 in the build matrix.

Thank you! Let me know if there is any way to make this  pull possible and easy.